### PR TITLE
Bugfix/custom url is not working on docker

### DIFF
--- a/lib/mirage/client/client.rb
+++ b/lib/mirage/client/client.rb
@@ -12,10 +12,10 @@ module Mirage
     def initialize options={:url => "http://localhost:7001"}, &block
       if options.is_a?(String) && options =~ URI.regexp
         @url = options
-      elsif options.kind_of?(Hash) && options[:port]
-        @url = "http://localhost:#{options[:port]}"
       elsif options.kind_of?(Hash) && options[:url]
         @url = options[:url]
+      elsif options.kind_of?(Hash) && options[:port]
+        @url = "http://localhost:#{options[:port]}"
       else
         raise "specify a valid URL or port"
       end

--- a/lib/mirage/client/runner.rb
+++ b/lib/mirage/client/runner.rb
@@ -42,12 +42,19 @@ module Mirage
     #   Mirage.running? :port => port -> boolean indicating whether Mirage is running on *locally* on the given port
     #   Mirage.running? url -> boolean indicating whether Mirage is running on the given URL
     def running? options_or_url = {:port => 7001}
-      url = options_or_url.kind_of?(Hash) ? "http://localhost:#{options_or_url[:port]}" : options_or_url
+      if options_or_url.kind_of?(Hash)
+        if options_or_url[:url]
+          url = options_or_url[:url]
+        else
+          url = "http://localhost:#{options_or_url[:port]}"
+        end
+      else
+        url = options_or_url
+      end
       HTTParty.get(url) and return true
     rescue Errno::ECONNREFUSED
       return false
     end
-
   end
 
   class Runner < Thor

--- a/spec/mirage/client/client_spec.rb
+++ b/spec/mirage/client/client_spec.rb
@@ -17,7 +17,7 @@ describe Mirage::Client do
       mirage_url = "http://url.for.mirage"
       Client.new(mirage_url).url.should == mirage_url
 
-      Client.new(:url => mirage_url).url.should == mirage_url
+      Client.new(:url => mirage_url, :port => 9001).url.should == mirage_url
     end
 
     it 'can be configured with a port refering to which port Mirage is running on on localhost' do

--- a/spec/mirage/client/runner_spec.rb
+++ b/spec/mirage/client/runner_spec.rb
@@ -42,7 +42,37 @@ describe Mirage do
       @runner.should_receive(:invoke).with(:stop, [], :port => ports)
       Mirage.stop(:port => ports)
     end
+  end
 
+  describe '.running?' do
+    before(:each) do
+      HTTParty.stub(:get)
+    end
+
+    it 'should check running app if you do not pass params' do
+      url = 'http://localhost:7001'
+      HTTParty.should_receive(:get).with(url).and_return(true)
+      Mirage.running?
+    end
+
+    it 'should check running app if you pass url as string' do
+      url = 'http://my.url:9000'
+      HTTParty.should_receive(:get).with(url).and_return(true)
+      Mirage.running?(url)
+    end
+
+    it 'should check running app if you pass url in hash' do
+      url = 'http://my.url:9000'
+      HTTParty.should_receive(:get).with(url).and_return(true)
+      Mirage.running?({:url => url})
+    end
+
+    it 'should check running app if you pass port in hash' do
+      url = 'http://localhost:1234'
+      port = 1234
+      HTTParty.should_receive(:get).with(url).and_return(true)
+      Mirage.running?({:port => port})
+    end
   end
 
   describe Mirage::Runner do
@@ -133,6 +163,5 @@ describe Mirage do
       Mirage::Runner.should_receive(:new).and_return(runner)
       expect { runner.invoke(:stop, [], options) }.not_to raise_error
     end
-
   end
 end


### PR DESCRIPTION
If you try to use Mirage with docker it will fail because:

1. In `Mirage.start (runner.rb:14)` it put default port. After that in `Mirage::Client` this if elsif `(client.rb:15)` will never use custom url because at first it check if there is port and if it could find it  `localhost` is used.
2. In `Runner.start` it use `Mirage.running?(options)` - `(runner.rb:91)` with `Hash` type param. Because of that it will always try to find if app is running as `localhost` not u custom url.

I tried to fix this error with backward compatibility. Classes interface stay almost this same.